### PR TITLE
Add script to monitor memory usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,14 @@
 ## Usage
 
-- Install [Quark][] and [gVisor][].
+- Install [Quark][]
+    - Use [commit b0dd795298c5804a0e323c6956d3149ce4a6c5e1](https://github.com/QuarkContainer/Quark/commit/92d1cb74ff6dbde184160e0bb400a7153a6f9e00)
+- Install [gVisor][].
+    - Use [commit f054c314ec020f0b26266f267221033ffda82b67](https://github.com/google/gvisor/commit/f054c314ec020f0b26266f267221033ffda82b67)
 - Install [Docker buildx plugin][buildx]
 - Build and install [second-state/runwasi][runwasi]
+    - Use [commit ba7ea907f8593ef677d46aee7edc0ff8e3cd4be8](https://github.com/second-state/runwasi/commit/ba7ea907f8593ef677d46aee7edc0ff8e3cd4be8)
 - Use [wasmedge branch of moby](https://github.com/CaptainVincent/moby/tree/wasmedge) for dockerd
+    - Use [commit 270211953ea4c3a88cae6eb566aa3a32d2d4b1ba](https://github.com/CaptainVincent/moby/commit/270211953ea4c3a88cae6eb566aa3a32d2d4b1ba)
 - Start `dockerd` with `quark` and `runsc` runtime and `config/daemon.json` config:
 
 ```
@@ -33,6 +38,8 @@ docker context use benchmark
         - We use `time` command to monitor time usage.
     - For memory measurement, the unit is MB (lower is better).
         - We use `docker stats` command to monitor memory usage.
+        - Since [runwasi][] does not support `docker stats` to get memory usage,
+          we did not list memory usage for `benchmark_wasmedge_quickjs` here.
 
 ```
 ### container_start_time
@@ -54,7 +61,6 @@ benchmark_name                      min      max      avg      std
 benchmark_runc_nodejs           341.400  369.200  352.990    8.389
 benchmark_quark_nodejs         1398.784 1446.912 1423.462   12.168
 benchmark_gvisor_nodejs         355.400  380.100  367.000    9.080
-benchmark_wasmedge_quickjs        0.000    0.000    0.000    0.000
 ```
 
 ## Environments

--- a/README.md
+++ b/README.md
@@ -28,22 +28,33 @@ docker context use benchmark
 ./benchmark.sh <COUNT>
 ```
 
-- Results (sec, lower is better):
+- Results
+    - For time measurement, the unit is sec (lower is better).
+        - We use `time` command to monitor time usage.
+    - For memory measurement, the unit is MB (lower is better).
+        - We use `docker stats` command to monitor memory usage.
 
 ```
 ### container_start_time
-benchmark_name                     min     max     avg     std
-benchmark_runc_nodejs            0.416   0.509   0.473   0.029
-benchmark_quark_nodejs           0.595   0.784   0.658   0.052
-benchmark_gvisor_nodejs          0.752   0.865   0.808   0.033
-benchmark_wasmedge_quickjs       0.343   0.465   0.408   0.037
+benchmark_name                      min      max      avg      std
+benchmark_runc_nodejs             0.419    0.454    0.436    0.011
+benchmark_quark_nodejs            0.572    0.626    0.606    0.016
+benchmark_gvisor_nodejs           0.671    0.759    0.707    0.027
+benchmark_wasmedge_quickjs        0.346    0.392    0.360    0.013
 
 ### container_execution_time
-benchmark_name                     min     max     avg     std
-benchmark_runc_nodejs           20.457  20.505  20.481   0.018
-benchmark_quark_nodejs          20.763  20.866  20.790   0.033
-benchmark_gvisor_nodejs         20.644  20.845  20.756   0.056
-benchmark_wasmedge_quickjs      54.324  58.383  55.724   1.460
+benchmark_name                      min      max      avg      std
+benchmark_runc_nodejs            20.422   20.856   20.504    0.128
+benchmark_quark_nodejs           20.701   20.804   20.753    0.032
+benchmark_gvisor_nodejs          20.590   20.800   20.658    0.061
+benchmark_wasmedge_quickjs       55.012   58.590   55.974    1.045
+
+### max_memory_usage
+benchmark_name                      min      max      avg      std
+benchmark_runc_nodejs           341.400  369.200  352.990    8.389
+benchmark_quark_nodejs         1398.784 1446.912 1423.462   12.168
+benchmark_gvisor_nodejs         355.400  380.100  367.000    9.080
+benchmark_wasmedge_quickjs        0.000    0.000    0.000    0.000
 ```
 
 ## Environments

--- a/utils/calculate.py
+++ b/utils/calculate.py
@@ -30,32 +30,45 @@ def get_data():
             container_start_time = []
             # container_execution_time = end - js
             container_execution_time = []
+            max_memory_usage = []
             current_timestamp = 0
+            current_max_memory_usage = 0
             for line in f.readlines():
-                m = re.match(r'^(start|js|end): ([\d\.]+)', line)
+                m = re.match(r'^(start|js|end|memory_usage): ([\d\.]+)', line)
                 if m is not None:
                     action = m.group(1)
-                    timestamp = float(m.group(2))
                     if action == 'start':
+                        timestamp = float(m.group(2))
                         current_timestamp = timestamp
                     elif action == 'js':
+                        timestamp = float(m.group(2))
                         container_start_time.append(timestamp - current_timestamp)
                         current_timestamp = timestamp
                     elif action == 'end':
+                        timestamp = float(m.group(2))
                         container_execution_time.append(timestamp - current_timestamp)
-                        current_timestamp = timestamp
+                        max_memory_usage.append(current_max_memory_usage)
+                        current_max_memory_usage = 0
+                m = re.match(r'^memory_usage: ([\d\.]+)(G|M)iB', line)
+                if m is not None:
+                    memory_usage = float(m.group(1))
+                    unit = m.group(2)
+                    if unit == 'G':
+                        memory_usage = memory_usage * 1024
+                    current_max_memory_usage = max(memory_usage, current_max_memory_usage)
             result[benchmark_name]['container_start_time'] = container_start_time
             result[benchmark_name]['container_execution_time'] = container_execution_time
+            result[benchmark_name]['max_memory_usage'] = max_memory_usage
     return result
 
 def print_data(data):
-    for action in ('container_start_time', 'container_execution_time'):
+    for action in ('container_start_time', 'container_execution_time', 'max_memory_usage'):
         print(f'### {action}')
         print('benchmark_name'.ljust(30) +
-              'min'.rjust(8) +
-              'max'.rjust(8) +
-              'avg'.rjust(8) +
-              'std'.rjust(8))
+              'min'.rjust(9) +
+              'max'.rjust(9) +
+              'avg'.rjust(9) +
+              'std'.rjust(9))
         for benchmark_name in BENCHMARKS:
             d = data[benchmark_name][action]
             minimum = min(d)
@@ -63,10 +76,11 @@ def print_data(data):
             average = statistics.mean(d)
             stdev = 0 if len(d) < 2 else statistics.stdev(d)
             print(f'{benchmark_name:30}'
-                  f'{minimum:8.3f}'
-                  f'{maximum:8.3f}'
-                  f'{average:8.3f}'
-                  f'{stdev:8.3f}')
+                  f'{minimum:9.3f}'
+                  f'{maximum:9.3f}'
+                  f'{average:9.3f}'
+                  f'{stdev:9.3f}')
+        print()
 
 def main():
     data = get_data()

--- a/utils/monitor.sh
+++ b/utils/monitor.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+set -o nounset
+set -o errexit
+set -o pipefail
+
+trap - SIGINT SIGTERM EXIT
+
+[ -z "${1-}" ] && echo "Usage: $0 <container_name>" && exit 1
+CONTAINER_NAME="$1"
+
+# wait until container is start
+while [[ $(docker inspect -f {{.State.Running}} "$CONTAINER_NAME") != "true" ]]
+do
+    sleep 1
+done
+
+while true
+do
+    mem=$(docker stats --no-stream --format '{{.MemUsage}}' "$CONTAINER_NAME" | awk '{print $1}')
+    echo "memory_usage: $mem"
+    sleep 1
+done


### PR DESCRIPTION
Use `docker stats` to monitor memory usage, found some issues:
- quark containers with high memory usage
- wasmedge containers do not show memory usage properly

Signed-off-by: dm4 <dm4@secondstate.io>